### PR TITLE
Reduce git-secrets alert

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -1,0 +1,6 @@
+# SVG file for fonts
+droid-sans-v6-latin-700.svg
+
+# README file URL of swagger-ui project
+# https://github.com/wordnik/swagger-ui/blob/f2e63c65a759421aad590b7275371cd0c06c74ea/src/main/html/index.html
+f2e63c65a759421aad590b7275371cd0c06c74ea


### PR DESCRIPTION
Strings used in README file (historical commit) and SVG file are triggering a lot of false positive alerts. Manual inspection confirmed there is no sensitive data in this file. Will greatly appreciate if someone can help to merge this PR. We also have PRs created in other repositories to address similar issue.

Thank you very much.

<img width="956" alt="4" src="https://user-images.githubusercontent.com/29866357/28160156-9c2793f2-67bf-11e7-89fc-c02565d0e21e.png">

@joh-m 